### PR TITLE
Fixed to build API Reference page 

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,5 @@
+build:
+  image: latest
+
+python:
+  version: 3.6


### PR DESCRIPTION
Fixed the problem that API Reference page is not rendered as for issue #25.

Read the Doc uses Python 3.5 by default. In the other hand, Blueqat uses Python 3.6 syntax such as f-strings format - f"xxx{variable}xxx". It causes build error on Read the Docs process, so I added .readthedocs.yml to specify Python version. Please note that the official say Python 3.6 is still beta state.
I confirmed the page is built correctly. Thanks.
